### PR TITLE
Adapt language variables names to current naming convention and update variables to cover new strings

### DIFF
--- a/languages.yaml
+++ b/languages.yaml
@@ -1,41 +1,49 @@
 en:
-    THEME_LEARN4_GITHUB_EDIT: Edit
-    THEME_LEARN4_GITHUB_NOTE: "Found errors? Think you can improve this documentation? Simply click the <strong><i class=\"fa fa-pencil-square\"></i> Edit</strong> link at the top of the page, and then the <strong><i class=\"fa fa-pencil\"></i></strong> icon on Github to make your changes."
-    THEME_LEARN4_CLEAR_HISTORY: Clear History
-    THEME_LEARN4_BUILT_WITH_GRAV: Built with <a href="http://getgrav.org">Grav</a> - The Modern Flat File CMS
-    THEME_LEARN4_SEARCH_DOCUMENTATION: Search...
+  THEME_LEARN4:
+    GITHUB_EDIT: Edit
+    GITHUB_NOTE: "Found errors? Think you can improve this documentation? Simply click the <strong><i class=\"fa fa-pencil-square\"></i> Edit</strong> link at the top of the page, and then the <strong><i class=\"fa fa-pencil\"></i></strong> icon on Github to make your changes."
+    CLEAR_HISTORY: Clear history
+    BUILT_WITH_GRAV: Built with <a href="http://getgrav.org">Grav</a> - The Modern Flat File CMS
+    SEARCH_DOCUMENTATION: Search...
 cn:
-    THEME_LEARN4_GITHUB_NOTE: 发现错误？请帮忙改进，谢谢！
-    THEME_LEARN4_CLEAR_HISTORY: 清除历史
-    THEME_LEARN4_BUILT_WITH_GRAV: Built with <a href="http://getgrav.org">Grav</a> - The Modern Flat File CMS
-    THEME_LEARN4_SEARCH_DOCUMENTATION: 搜索文档
+  THEME_LEARN4:
+    GITHUB_NOTE: 发现错误？请帮忙改进，谢谢！
+    CLEAR_HISTORY: 清除历史
+    BUILT_WITH_GRAV: Built with <a href="http://getgrav.org">Grav</a> - The Modern Flat File CMS
+    SEARCH_DOCUMENTATION: 搜索文档
 cs:
-    THEME_LEARN4_GITHUB_NOTE: Našli jste chybu? Myslíte, že můžete vylepšit tuto dokumentaci?
-    THEME_LEARN4_CLEAR_HISTORY: Smazat historii
-    THEME_LEARN4_BUILT_WITH_GRAV: Postaveno na <a href="http://getgrav.org">Grav</a> - Moderní správce obsahu pomocí souborů prostých textů
-    THEME_LEARN4_SEARCH_DOCUMENTATION: Vyhledat v dokumentaci
+  THEME_LEARN4:
+    GITHUB_NOTE: Našli jste chybu? Myslíte, že můžete vylepšit tuto dokumentaci?
+    CLEAR_HISTORY: Smazat historii
+    BUILT_WITH_GRAV: Postaveno na <a href="http://getgrav.org">Grav</a> - Moderní správce obsahu pomocí souborů prostých textů
+    SEARCH_DOCUMENTATION: Vyhledat v dokumentaci
 de:
-    THEME_LEARN4_GITHUB_NOTE: Fehler gefunden? Möchten Sie diese Seite verbessern?
-    THEME_LEARN4_CLEAR_HISTORY: Verlauf löschen
-    THEME_LEARN4_BUILT_WITH_GRAV: Seite erstellt mit <a href="http://getgrav.org">Grav</a> - The Modern Flat File CMS
-    THEME_LEARN4_SEARCH_DOCUMENTATION: Dokumentation durchsuchen
+  THEME_LEARN4:
+    GITHUB_NOTE: Fehler gefunden? Möchten Sie diese Seite verbessern?
+    CLEAR_HISTORY: Verlauf löschen
+    BUILT_WITH_GRAV: Seite erstellt mit <a href="http://getgrav.org">Grav</a> - The Modern Flat File CMS
+    SEARCH_DOCUMENTATION: Dokumentation durchsuchen
 es:
-    THEME_LEARN4_GITHUB_NOTE: ¿Encontraste errores? ¿Crees que puedes mejorar esta documentación?
-    THEME_LEARN4_CLEAR_HISTORY: Limpiar historial
-    THEME_LEARN4_BUILT_WITH_GRAV: Hecho con <a href="http://getgrav.org">Grav</a> - El CMS moderno de archivos planos
-    THEME_LEARN4_SEARCH_DOCUMENTATION: Buscar en la documentación
+  THEME_LEARN4:
+    GITHUB_NOTE: ¿Encontraste errores? ¿Crees que puedes mejorar esta documentación?
+    CLEAR_HISTORY: Limpiar historial
+    BUILT_WITH_GRAV: Hecho con <a href="http://getgrav.org">Grav</a> - El CMS moderno de archivos planos
+    SEARCH_DOCUMENTATION: Buscar en la documentación
 fr:
-    THEME_LEARN4_GITHUB_NOTE: Vous avez découvert des erreurs ? Vous pensez pouvoir améliorer cette documentation ?
-    THEME_LEARN4_CLEAR_HISTORY: Effacer l'historique
-    THEME_LEARN4_BUILT_WITH_GRAV: Créé avec <a href="http://getgrav.org">Grav</a> - Le CMS moderne sans base de données
-    THEME_LEARN4_SEARCH_DOCUMENTATION: Rechercher dans la documentation
+  THEME_LEARN4:
+    GITHUB_NOTE: Vous avez découvert des erreurs ? Vous pensez pouvoir améliorer cette documentation ?
+    CLEAR_HISTORY: Effacer l'historique
+    BUILT_WITH_GRAV: Créé avec <a href="http://getgrav.org">Grav</a> - Le CMS moderne sans base de données
+    SEARCH_DOCUMENTATION: Rechercher dans la documentation
 it:
-    THEME_LEARN4_GITHUB_NOTE: Hai trovato degli errori? Pensi di poter migliorare questa documentazione?
-    THEME_LEARN4_CLEAR_HISTORY: Cancella Cronologia
-    THEME_LEARN4_BUILT_WITH_GRAV: Built with <a href="http://getgrav.org">Grav</a> - The Modern Flat File CMS
-    THEME_LEARN4_SEARCH_DOCUMENTATION: Cerca nella Documentatione
+  THEME_LEARN4:
+    GITHUB_NOTE: Hai trovato degli errori? Pensi di poter migliorare questa documentazione?
+    CLEAR_HISTORY: Cancella cronologia
+    BUILT_WITH_GRAV: Built with <a href="http://getgrav.org">Grav</a> - The Modern Flat File CMS
+    SEARCH_DOCUMENTATION: Cerca nella documentatione
 ru:
-    THEME_LEARN4_GITHUB_NOTE: Нашли ошибки? Думаете, что можете улучшить документацию?
-    THEME_LEARN4_CLEAR_HISTORY: Очистить историю
-    THEME_LEARN4_BUILT_WITH_GRAV: Сделано на <a href="http://getgrav.org">Grav</a> — современной файловой CMS
-    THEME_LEARN4_SEARCH_DOCUMENTATION: Поиск по документации
+  THEME_LEARN4:
+    GITHUB_NOTE: Нашли ошибки? Думаете, что можете улучшить документацию?
+    CLEAR_HISTORY: Очистить историю
+    BUILT_WITH_GRAV: Сделано на <a href="http://getgrav.org">Grav</a> — современной файловой CMS
+    SEARCH_DOCUMENTATION: Поиск по документации

--- a/languages.yaml
+++ b/languages.yaml
@@ -1,61 +1,81 @@
 en:
   THEME_LEARN4:
-    GITHUB_EDIT: Edit
-    GITHUB_NOTE: "Found errors? Think you can improve this documentation? Simply click the <strong><i class=\"fa fa-pencil-square\"></i> Edit</strong> link at the top of the page, and then the <strong><i class=\"fa fa-pencil\"></i></strong> icon on Github to make your changes."
+    GITHUB:
+      BUTTON: Edit
+      TOOLTIP: Edit on GitHub
+      NOTE: Found errors? Think you can improve this documentation? Simply click the <strong><i class="fa fa-pencil-square"></i> Edit</strong> link at the top of the page, and then the <strong><i class="fa fa-pencil"></i></strong> icon on GitHub to make your changes.
+    NAV_PREV: Previous page
+    NAV_NEXT: Next page
     CLEAR_HISTORY: Clear history
-    BUILT_WITH_GRAV: Built with <a href="http://getgrav.org">Grav</a> - The Modern Flat File CMS
-    SEARCH_DOCUMENTATION: Search...
+    SEARCH:
+      TEXT: Search...
+      ADVC: Advanced
+    POWERED_BY_GRAV: Powered by <a href="http://getgrav.org">Grav</a> + <i class="fa fa-code"></i> with <i class="fa fa-heart-o pulse"></i> by <a href="https://trilby.media">Trilby Media</a>.
 cn:
   THEME_LEARN4:
-    GITHUB_NOTE: 发现错误？请帮忙改进，谢谢！
+    GITHUB:
+      NOTE: 发现错误？请帮忙改进，谢谢！ Simply click the <strong><i class="fa fa-pencil-square"></i> Edit</strong> link at the top of the page, and then the <strong><i class="fa fa-pencil"></i></strong> icon on GitHub to make your changes.
     CLEAR_HISTORY: 清除历史
-    BUILT_WITH_GRAV: Built with <a href="http://getgrav.org">Grav</a> - The Modern Flat File CMS
-    SEARCH_DOCUMENTATION: 搜索文档
+    SEARCH:
+      TEXT: 搜索文档
 cs:
   THEME_LEARN4:
-    GITHUB_NOTE: Našli jste chybu? Myslíte, že můžete vylepšit tuto dokumentaci?
+    GITHUB:
+      NOTE: Našli jste chybu? Myslíte, že můžete vylepšit tuto dokumentaci? Simply click the <strong><i class="fa fa-pencil-square"></i> Edit</strong> link at the top of the page, and then the <strong><i class="fa fa-pencil"></i></strong> icon on GitHub to make your changes.
     CLEAR_HISTORY: Smazat historii
-    BUILT_WITH_GRAV: Postaveno na <a href="http://getgrav.org">Grav</a> - Moderní správce obsahu pomocí souborů prostých textů
-    SEARCH_DOCUMENTATION: Vyhledat v dokumentaci
+    SEARCH:
+      TEXT: Vyhledat v dokumentaci
 de:
   THEME_LEARN4:
-    GITHUB_NOTE: Fehler gefunden? Möchten Sie diese Seite verbessern?
+    GITHUB:
+      NOTE: Fehler gefunden? Möchten Sie diese Seite verbessern? Simply click the <strong><i class="fa fa-pencil-square"></i> Edit</strong> link at the top of the page, and then the <strong><i class="fa fa-pencil"></i></strong> icon on GitHub to make your changes.
     CLEAR_HISTORY: Verlauf löschen
-    BUILT_WITH_GRAV: Seite erstellt mit <a href="http://getgrav.org">Grav</a> - The Modern Flat File CMS
-    SEARCH_DOCUMENTATION: Dokumentation durchsuchen
+    SEARCH:
+      TEXT: Dokumentation durchsuchen
 es:
   THEME_LEARN4:
-    GITHUB_NOTE: ¿Encontraste errores? ¿Crees que puedes mejorar esta documentación?
+    GITHUB:
+      BUTTON: Editar
+      TOOLTIP: Editar en GitHub
+      NOTE: ¿Encontraste errores? ¿Crees que puedes mejorar esta página? Para hacer tus cambios, simplemente haz click en el enlace <strong><i class="fa fa-pencil-square"></i> Editar</strong> arriba de esta página y, tras ello, en el icono <strong><i class="fa fa-pencil"></i></strong> en GitHub.
+    NAV_PREV: Pág. anterior
+    NAV_NEXT: Pág. siguiente
     CLEAR_HISTORY: Limpiar historial
-    BUILT_WITH_GRAV: Hecho con <a href="http://getgrav.org">Grav</a> - El CMS moderno de archivos planos
-    SEARCH_DOCUMENTATION: Buscar en la documentación
+    SEARCH:
+      TEXT: Buscar...
+      ADVC: Avanzado
 fr:
   THEME_LEARN4:
-    GITHUB_NOTE: Vous avez découvert des erreurs ? Vous pensez pouvoir améliorer cette documentation ?
+    GITHUB:
+      NOTE: Vous avez découvert des erreurs ? Vous pensez pouvoir améliorer cette documentation? Simply click the <strong><i class="fa fa-pencil-square"></i> Edit</strong> link at the top of the page, and then the <strong><i class="fa fa-pencil"></i></strong> icon on GitHub to make your changes.
     CLEAR_HISTORY: Effacer l'historique
-    BUILT_WITH_GRAV: Créé avec <a href="http://getgrav.org">Grav</a> - Le CMS moderne sans base de données
-    SEARCH_DOCUMENTATION: Rechercher dans la documentation
+    SEARCH:
+      TEXT: Rechercher dans la documentation
 it:
   THEME_LEARN4:
-    GITHUB_NOTE: Hai trovato degli errori? Pensi di poter migliorare questa documentazione?
+    GITHUB:
+      NOTE: Hai trovato degli errori? Pensi di poter migliorare questa documentazione? Simply click the <strong><i class="fa fa-pencil-square"></i> Edit</strong> link at the top of the page, and then the <strong><i class="fa fa-pencil"></i></strong> icon on GitHub to make your changes.
     CLEAR_HISTORY: Cancella cronologia
-    BUILT_WITH_GRAV: Built with <a href="http://getgrav.org">Grav</a> - The Modern Flat File CMS
-    SEARCH_DOCUMENTATION: Cerca nella documentatione
+    SEARCH:
+      TEXT: Cerca nella documentatione
 pt:
   THEME_LEARN4:
-    GITHUB_NOTE: Encontrou erros? Achas que pode melhorar esta documentação?
+    GITHUB:
+      NOTE: Encontrou erros? Achas que pode melhorar esta documentação? Simply click the <strong><i class="fa fa-pencil-square"></i> Edit</strong> link at the top of the page, and then the <strong><i class="fa fa-pencil"></i></strong> icon on GitHub to make your changes.
     CLEAR_HISTORY: Limpar histórico
-    BUILT_WITH_GRAV: Feito com <a href="http://getgrav.org">Grav</a> - O CMS Moderno de ficheiros planos
-    SEARCH_DOCUMENTATION: Procurar documentação
+    SEARCH:
+      TEXT: Procurar documentação
 pt-BR:
   THEME_LEARN4:
-    GITHUB_NOTE: Encontrou erros? Acha que pode melhorar essa documentação?
+    GITHUB:
+      NOTE: Encontrou erros? Acha que pode melhorar essa documentação? Simply click the <strong><i class="fa fa-pencil-square"></i> Edit</strong> link at the top of the page, and then the <strong><i class="fa fa-pencil"></i></strong> icon on GitHub to make your changes.
     CLEAR_HISTORY: Limpar histórico
-    BUILT_WITH_GRAV: Feito com <a href="http://getgrav.org">Grav</a> - O CMS Moderno de arquivos planos
-    SEARCH_DOCUMENTATION: Procurar documentação
+    SEARCH:
+      TEXT: Procurar documentação
 ru:
   THEME_LEARN4:
-    GITHUB_NOTE: Нашли ошибки? Думаете, что можете улучшить документацию?
+    GITHUB:
+      NOTE: Нашли ошибки? Думаете, что можете улучшить документацию? Simply click the <strong><i class="fa fa-pencil-square"></i> Edit</strong> link at the top of the page, and then the <strong><i class="fa fa-pencil"></i></strong> icon on GitHub to make your changes.
     CLEAR_HISTORY: Очистить историю
-    BUILT_WITH_GRAV: Сделано на <a href="http://getgrav.org">Grav</a> — современной файловой CMS
-    SEARCH_DOCUMENTATION: Поиск по документации
+    SEARCH:
+      TEXT: Поиск по документации

--- a/languages.yaml
+++ b/languages.yaml
@@ -41,6 +41,18 @@ it:
     CLEAR_HISTORY: Cancella cronologia
     BUILT_WITH_GRAV: Built with <a href="http://getgrav.org">Grav</a> - The Modern Flat File CMS
     SEARCH_DOCUMENTATION: Cerca nella documentatione
+pt:
+  THEME_LEARN4:
+    GITHUB_NOTE: Encontrou erros? Achas que pode melhorar esta documentação?
+    CLEAR_HISTORY: Limpar histórico
+    BUILT_WITH_GRAV: Feito com <a href="http://getgrav.org">Grav</a> - O CMS Moderno de ficheiros planos
+    SEARCH_DOCUMENTATION: Procurar documentação
+pt-BR:
+  THEME_LEARN4:
+    GITHUB_NOTE: Encontrou erros? Acha que pode melhorar essa documentação?
+    CLEAR_HISTORY: Limpar histórico
+    BUILT_WITH_GRAV: Feito com <a href="http://getgrav.org">Grav</a> - O CMS Moderno de arquivos planos
+    SEARCH_DOCUMENTATION: Procurar documentação
 ru:
   THEME_LEARN4:
     GITHUB_NOTE: Нашли ошибки? Думаете, что можете улучшить документацию?

--- a/templates/partials/footer.html.twig
+++ b/templates/partials/footer.html.twig
@@ -1,5 +1,7 @@
 <section id="footer" class="section">
     <section class="container {{ grid_size }}">
-        <p>Powered by <a href="http://getgrav.org">Grav</a> + <i class="fa fa-code"></i> with <i class="fa fa-heart-o pulse "></i> by <a href="https://trilby.media">Trilby Media</a>.</p>
+      <p>
+        {{ 'THEME_LEARN4.POWERED_BY_GRAV'|t|raw }}
+      </p>
     </section>
 </section>

--- a/templates/partials/github-link.html.twig
+++ b/templates/partials/github-link.html.twig
@@ -1,1 +1,1 @@
-<a class="github-link tooltip tooltip-bottom" href="{{ github_config.tree ~  ('/'~page.filePathClean)|replace({'/user/':''}) }}" data-tooltip="Edit this page on GitHub"><i class="fa fa-pencil-square"></i> {{ 'THEME_LEARN4_GITHUB_EDIT'|t }}</a>
+<a class="github-link tooltip tooltip-bottom" href="{{ github_config.tree ~  ('/'~page.filePathClean)|replace({'/user/':''}) }}" data-tooltip="Edit this page on GitHub"><i class="fa fa-pencil-square"></i> {{ 'THEME_LEARN4.GITHUB_EDIT'|t }}</a>

--- a/templates/partials/github-link.html.twig
+++ b/templates/partials/github-link.html.twig
@@ -1,1 +1,1 @@
-<a class="github-link tooltip tooltip-bottom" href="{{ github_config.tree ~  ('/'~page.filePathClean)|replace({'/user/':''}) }}" data-tooltip="Edit this page on GitHub"><i class="fa fa-pencil-square"></i> {{ 'THEME_LEARN4.GITHUB_EDIT'|t }}</a>
+<a class="github-link tooltip tooltip-bottom" href="{{ github_config.tree ~  ('/'~page.filePathClean)|replace({'/user/':''}) }}" data-tooltip="{{ 'THEME_LEARN4.GITHUB.TOOLTIP'|t }}"><i class="fa fa-pencil-square"></i> {{ 'THEME_LEARN4.GITHUB.BUTTON'|t }}</a>

--- a/templates/partials/github-note.html.twig
+++ b/templates/partials/github-note.html.twig
@@ -1,6 +1,6 @@
 <div class="notices note">
   <p>
-    {{ 'THEME_LEARN4_GITHUB_NOTE'|t|raw }}
+    {{ 'THEME_LEARN4.GITHUB_NOTE'|t|raw }}
   </p>
 </div>
 

--- a/templates/partials/github-note.html.twig
+++ b/templates/partials/github-note.html.twig
@@ -1,6 +1,5 @@
 <div class="notices note">
   <p>
-    {{ 'THEME_LEARN4.GITHUB_NOTE'|t|raw }}
+    {{ 'THEME_LEARN4.GITHUB.NOTE'|t|raw }}
   </p>
 </div>
-

--- a/templates/partials/sidebar.html.twig
+++ b/templates/partials/sidebar.html.twig
@@ -5,12 +5,12 @@
         <a id="logo" href="{{ theme_config.home_url ?: base_url_absolute }}">{% include 'partials/logo.html.twig' %}</a>
         <div class="searchbox">
             <label for="search-by"><i class="fa fa-search"></i></label>
-            <input id="search-by" type="text" placeholder="{{ 'THEME_LEARN4.SEARCH_DOCUMENTATION'|t }}"
+            <input id="search-by" type="text" placeholder="{{ 'THEME_LEARN4.SEARCH.TEXT'|t }}"
                    data-search-input="{{ base_url_relative }}/s/q"/>
             <span data-search-clear><i class="fa fa-close"></i></span>
         </div>
         <div class="search-options columns">
-            <div class="adv-search column col-8"><i class="fa fa-sliders"></i> <a href="{{ url('search') }}">Advanced</a></div>
+            <div class="adv-search column col-8"><i class="fa fa-sliders"></i> <a href="{{ url('search') }}">{{ 'THEME_LEARN4.SEARCH.ADVC'|t }}</a></div>
             {% include 'partials/versions.html.twig' %}
         </div>
     </div>

--- a/templates/partials/sidebar.html.twig
+++ b/templates/partials/sidebar.html.twig
@@ -5,7 +5,7 @@
         <a id="logo" href="{{ theme_config.home_url ?: base_url_absolute }}">{% include 'partials/logo.html.twig' %}</a>
         <div class="searchbox">
             <label for="search-by"><i class="fa fa-search"></i></label>
-            <input id="search-by" type="text" placeholder="{{ 'THEME_LEARN4_SEARCH_DOCUMENTATION'|t }}"
+            <input id="search-by" type="text" placeholder="{{ 'THEME_LEARN4.SEARCH_DOCUMENTATION'|t }}"
                    data-search-input="{{ base_url_relative }}/s/q"/>
             <span data-search-clear><i class="fa fa-close"></i></span>
         </div>
@@ -36,7 +36,7 @@
         <hr />
 
         <a class="side-tools padding" href="#" data-clear-history-toggle>
-            <i class="fa fa-fw fa-history"></i> {{ 'THEME_LEARN4_CLEAR_HISTORY'|t }}
+            <i class="fa fa-fw fa-history"></i> {{ 'THEME_LEARN4.CLEAR_HISTORY'|t }}
         </a><br/>
     </div>
 </div>

--- a/templates/partials/topbar.html.twig
+++ b/templates/partials/topbar.html.twig
@@ -14,17 +14,15 @@
       {% include 'partials/github-link.html.twig' %}
     {% endif %}
     {% if not progress.isFirst(page.path) %}
-      <a class="nav-prev tooltip tooltip-bottom" data-tooltip="Previous Page [&larr;]" href="{{ progress.nextSibling(page.path).url }}"> <i class="fa fa-angle-left"></i></a>
+      <a class="nav-prev tooltip tooltip-bottom" data-tooltip="{{ 'THEME_LEARN4.NAV_PREV'|t }} [&larr;]" href="{{ progress.nextSibling(page.path).url }}"> <i class="fa fa-angle-left"></i></a>
     {% else %}
       <span class="disabled"><i class="fa fa-angle-left"></i></span>
     {% endif %}
     {% if not progress.isLast(page.path) %}
-      <a class="nav-next tooltip tooltip-bottom" data-tooltip="Next Page [&rarr;]" href="{{ progress.prevSibling(page.path).url }}"><i class="fa fa-angle-right"></i></a>
+      <a class="nav-next tooltip tooltip-bottom" data-tooltip="{{ 'THEME_LEARN4.NAV_NEXT'|t }} [&rarr;]" href="{{ progress.prevSibling(page.path).url }}"><i class="fa fa-angle-right"></i></a>
     {% else %}
       <span class="disabled"><i class="fa fa-angle-right"></i></span>
     {% endif %}
   </div>
   <div class="progress"></div>
 </div>
-
-


### PR DESCRIPTION
On 822e3c0e5598c24b7c450628d9bd68d9f6fd58e2: Variables names in `languages.yaml` did not follow the [established convention](https://learn.getgrav.org/17/content/multi-language#plugin-and-theme-language-translations).

On afcde3d7d121822e5184a9de9a8e18da155c8cde: Add pt/pt-BR to languages.yaml. Credits to @luizvaz.

On 0e095e57ca66b5583691dcf8374f7964149c26ca: Update language variables to cover new strings.
- GITHUB.BUTTON, and GITHUB.NOTE replace GITHUB_EDIT and GITHUB_NOTE.
- GITHUB.TOOLTIP, NAV_PREV, and NAV_NEXT are new and cover tooltips.
- SEARCH.TEXT replaces SEARCH_DOCUMENTATION.
- SEARCH.ADVC is new.
- POWERED_BY_GRAV replaces BUILT_WITH_GRAV

The new text from GITHUB.NOTE has been added to the other languages to
enforce contributions.

Fullty translated to Spanish to provide proper testing.