### PR TITLE
add template logic for github.note theme var

### DIFF
--- a/templates/docs.html.twig
+++ b/templates/docs.html.twig
@@ -13,5 +13,7 @@
 
     {% include 'partials/page.html.twig' %}
 
-    {% include 'partials/github-note.html.twig' %}
+    {% if theme_var('github.note') %}
+        {% include 'partials/github-note.html.twig' %}
+    {% endif %}
 {% endblock %}


### PR DESCRIPTION
The learn4.yaml setting `github.note` now affects the corresponding template code